### PR TITLE
fix/SA-251 cloudwatch retention default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ module "account_baseline_alarms" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_notifications"></a> [notifications](#module\_notifications) | appvia/notifications/aws | 1.0.1 |
+| <a name="module_notifications"></a> [notifications](#module\_notifications) | appvia/notifications/aws | 1.0.2 |
 
 ## Resources
 

--- a/examples/basic/.terraform.lock.hcl
+++ b/examples/basic/.terraform.lock.hcl
@@ -2,68 +2,80 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.43.0"
+  version     = "5.66.0"
   constraints = ">= 4.8.0, >= 4.9.0, >= 5.0.0, ~> 5.0, >= 5.25.0"
   hashes = [
-    "h1:3w6NCYy+mbc9odXmM7K5Xag2ggtapraacZqJR3WpJKc=",
-    "zh:07fb2abb9cf4d2042b41b2b2c642d4c4bd2feccbd856cd7040a7d15158fed478",
-    "zh:1373339e796d8d8473c267c0ecddb701559fce454c2cdd192cf8b0eadf759b48",
-    "zh:1644b4e0fd2e0b28d465bb5cf08b1f594a623324d176e879e5052f78cd2ea8cb",
-    "zh:385943b8d4170c5269b8e13e876636b7edc0ad2576edc7eb5d81cd4286a461d8",
-    "zh:48cf103f4fa866b67b686e8c085ac15264d6f020b6ad4a90f496b7283d31faa6",
-    "zh:4a4c4b4236542089d1bdb688c248e0b7c941ce42887da87e487bfb15038dcaf9",
-    "zh:5d84f3e12100bdd62a8c295b56358b82afc130642dca80d104bd868fdc28ed7c",
-    "zh:68294a601ce588a8838bcf4e136bb5ed8d2b1ee410f8871d88e35ce4861cf33f",
-    "zh:7ae1af6e9b95bd6c33dd0922216ac2b59f2f5b22fedbeab1db7a80b2f4358919",
-    "zh:89c718d41b2eeeaefd1acdbd839f1326a8c866bd49752648b0b32d3dd4a38163",
-    "zh:96e54ccb0f5ddf60465edf5c9f46e64f7d2f392507b851f102723797b4a15d09",
+    "h1:4GInuhb6IqucmxJ0wnkU8rn9kZ59usR5KpEhxbDiFHQ=",
+    "h1:E3IqCLIq+m45oalIE+cJL8nhh6slVAEkTMQam5QC5Vg=",
+    "h1:RHs4rOiKrKJqr8UhVW7yqfoMVwaofQ+9ChP41rAzc1A=",
+    "h1:q04VHjxAyH71dKTfMvrUuap88czr8vpiS8MsN7mDn9A=",
+    "h1:yGcVdhj9IKbS/b7BSHtgGjCiFnKK+81ImkK/x7UCgEI=",
+    "zh:071c908eb18627f4becdaf0a9fe95d7a61f69be365080aba2ef5e24f6314392b",
+    "zh:3dea2a474c6ad4be5b508de4e90064ec485e3fbcebb264cb6c4dec660e3ea8b5",
+    "zh:56c0b81e3bbf4e9ccb2efb984f8758e2bc563ce179ff3aecc1145df268b046d1",
+    "zh:5f34b75a9ef69cad8c79115ecc0697427d7f673143b81a28c3cf8d5decfd7f93",
+    "zh:65632bc2c408775ee44cb32a72e7c48376001a9a7b3adbc2c9b4d088a7d58650",
+    "zh:6d0550459941dfb39582fadd20bfad8816255a827bfaafb932d51d66030fcdd5",
+    "zh:7f1811ef179e507fdcc9776eb8dc3d650339f8b84dd084642cf7314c5ca26745",
+    "zh:8a793d816d7ef57e71758fe95bf830cfca70d121df70778b65cc11065ad004fd",
+    "zh:8c7cda08adba01b5ae8cc4e5fbf16761451f0fab01327e5f44fc47b7248ba653",
+    "zh:96d855f1771342771855c0fb2d47ff6a731e8f2fa5d242b18037c751fd63e6c3",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b102ce204ebbbf32d68ff47b5224eeb60873bef5b58a7fd7790f6b4020801578",
-    "zh:cae4cb16d15ac4b15c8de5bc9dddc2032583e12c4f31e23b3a7ef22da60657dc",
-    "zh:fecbcbd63111c9518de261bcb37482cb06ee149e7298f567d45b2a55674faa75",
+    "zh:b2a62669b72c2471820410b58d764102b11c24e326831ddcfae85c7d20795acf",
+    "zh:b4a6b251ac24c8f5522581f8d55238d249d0008d36f64475beefc3791f229e1d",
+    "zh:ca519fa7ee1cac30439c7e2d311a0ecea6a5dae2d175fe8440f30133688b6272",
+    "zh:fbcd54e7d65806b0038fc8a0fbdc717e1284298ff66e22aac39dcc5a22cc99e5",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/awscc" {
-  version     = "0.72.1"
+  version     = "1.13.0"
   constraints = ">= 0.11.0"
   hashes = [
-    "h1:gBjbggDnnBqY/YbCnvYOOFu/vdvGINJD8eC6cZJGXOE=",
-    "zh:13aa98bc2ab92f20cc1bc2422729e3e9139bd6091f7b2b298b971164c26267c7",
-    "zh:18df76f78131ce5bd793903b2e44aa5d792fce85cf253a1098d784ec3b1a7b9f",
-    "zh:23e47f602af1c016834bcb2976e3b95c06108b15dc6f6620fec74e972627e07a",
-    "zh:54cde9da23fb89e744ed04f37e1a18c300ef0995a6370ce4c63ae99a0373523f",
-    "zh:5c72236b8f4f929765b872665386a5076479cd149c86a17c52205038decafb0a",
-    "zh:5ec0bcc0012b9fc309f8434eed97a1e37d7d75ec2accccf4eac7f27287447efe",
-    "zh:67acda2e3695c4b367484942784ebae880e658a232ad403516a47e975915c7d0",
-    "zh:7b3ad8eaedef879a9785e4ad648da5b010ce38ff1a1feffa26c1ccaad50c5cdc",
-    "zh:847bb44ac1a2370f853b07cae308667a4d2896210d765ec4c777502d9e6d9161",
-    "zh:8b84b4861c1dcbebe225e916633845e7b63fcabe9ffceb71479b8d636a4e6d20",
-    "zh:9bcce134b2200745b481e9736673a8078be601283b6e3b3b2a236a12e1752bb0",
-    "zh:aeb81cadd6e75a5772ec74c62c4f78c570714021267f620209ab191d4cff1a0c",
-    "zh:f6fa3e879c6641b8c607842969be8bc33b1d18f15697d24598860a4466329006",
-    "zh:f73940f5936940e59ce3e7422d41c696b7b4d7f36c73da5c70c14a9f832115be",
+    "h1:0tAiC+3PZ6MPAPF34lBeoROykSdZwTr+jRsqVXinrLM=",
+    "h1:IIcCmhIrGc/3Z0e5LiR/ORn0PzhLZsWk9Jfqp8PoIZ0=",
+    "h1:S1rY/tSPrJTL+5cZ7LEbiWuJDbmkQQMfUeVzvc9IeVk=",
+    "h1:ZK0QO1GvrWnteg5AyekIBrenFQwzxnfiqF/utNDQOSA=",
+    "h1:rrWy6p8+SruYdtC7ffnA2SvK5S9Y5WXTrqYk66Aalrw=",
+    "zh:1c041cdab00f1ecf44f05c851d325ba05d90d61515f2060c70ed2a7ced673397",
+    "zh:1c71f3706786fe5c4b437ffc96e795e2a0a7df1abebce33968c8feb53b95b066",
+    "zh:38b1d7c30b2e464848d4a800b3fc2d1668d799ecfe5a8678db3d3cea1f310496",
+    "zh:4aa66969c2d91083cb58c71e10efe1713242a288027101311878f3331f606641",
+    "zh:5090f5341b9dc136166e314b90d7ec56614aea31d3065080c84e6b715068ab7b",
+    "zh:66c66f5f74b4b9253d5217397013c0b3ce28d77be0e8c1b530eb15e7ede12587",
+    "zh:72f519d2241befe95eba8d47c19a650d79285a90a7a03e00e8555614c213fec9",
+    "zh:85eeb5f5800e8ce1ae0d4dff4d4c7d11fe971980a648953dec3c88727789da9c",
+    "zh:b6e9516011684610186ee4d1505393ce4a19b76301225e5868879dacfe2ce6b0",
+    "zh:bc22672c5d06d0af0ac11cc7e421338a5196a8a8172e56ecbd785ed3ff95f9e3",
+    "zh:ddbe3db49b4f14dd7037eb26dc1d4ce0fa5d641746d2cc78a68ced91e88563cd",
+    "zh:e0e30c21f1ee885dcd7f0debe4b56458364b7a8975be03cedefb8b80667b940d",
+    "zh:eab6c0b5ae35bc3e3670c06f0976be4ccfb8c060018bff1fa8370215e04f64f3",
+    "zh:ec646db7281c7d01bd54e403ddc27f2f57f3fd8bdda4c77be548d941e3eb5d8a",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/external" {
-  version     = "2.3.3"
+  version     = "2.3.4"
   constraints = ">= 1.0.0"
   hashes = [
-    "h1:gShzO1rJtADK9tDZMvMgjciVAzsBh39LNjtThCwX1Hg=",
-    "zh:03d81462f9578ec91ce8e26f887e34151eda0e100f57e9772dbea86363588239",
-    "zh:37ec2a20f6a3ec3a0fd95d3f3de26da6cb9534b30488bc45723e118a0911c0d8",
-    "zh:4eb5b119179539f2749ce9de0e1b9629d025990f062f4f4dddc161562bb89d37",
-    "zh:5a31bb58414f41bee5e09b939012df5b88654120b0238a89dfd6691ba197619a",
-    "zh:6221a05e52a6a2d4f520ffe7cbc741f4f6080e0855061b0ed54e8be4a84eb9b7",
+    "h1:8mByRL3zDm50yiEXMrKtWC2FaLwuvvyjKI+eWuD1dn0=",
+    "h1:U6W8rgrdmR2pZ2cicFoGOSQ4GXuIf/4EK7s0vTJN7is=",
+    "h1:XWkRZOLKMjci9/JAtE8X8fWOt7A4u+9mgXSUjc4Wuyo=",
+    "h1:cCabxnWQ5fX1lS7ZqgUzsvWmKZw9FA7NRxAZ94vcTcc=",
+    "h1:fjJwsIgh+BJEy8FsSt6HD0rKgA9iDCC+Rkv7IGNdNxc=",
+    "zh:037fd82cd86227359bc010672cd174235e2d337601d4686f526d0f53c87447cb",
+    "zh:0ea1db63d6173d01f2fa8eb8989f0809a55135a0d8d424b08ba5dabad73095fa",
+    "zh:17a4d0a306566f2e45778fbac48744b6fd9c958aaa359e79f144c6358cb93af0",
+    "zh:298e5408ab17fd2e90d2cd6d406c6d02344fe610de5b7dae943a58b958e76691",
+    "zh:38ecfd29ee0785fd93164812dcbe0664ebbe5417473f3b2658087ca5a0286ecb",
+    "zh:59f6a6f31acf66f4ea3667a555a70eba5d406c6e6d93c2c641b81d63261eeace",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8bb068496b4679bef625e4710d9f3432e301c3a56602271f04e60eadf7f8a94c",
-    "zh:94742aa5378bab626ce34f79bcef6a373e4f86ea7a8b762e9f71270a899e0d00",
-    "zh:a485831b5a525cd8f40e8982fa37da40ff70b1ae092c8b755fcde123f0b1238d",
-    "zh:a647ff16d071eabcabd87ea8183eb90a775a0294ddd735d742075d62fff09193",
-    "zh:b74710c5954aaa3faf262c18d36a8c2407862d9f842c63e7fa92fa4de3d29df6",
-    "zh:fa73d83edc92af2e551857594c2232ba6a9e3603ad34b0a5940865202c08d8d7",
+    "zh:ad0279dfd09d713db0c18469f585e58d04748ca72d9ada83883492e0dd13bd58",
+    "zh:c69f66fd21f5e2c8ecf7ca68d9091c40f19ad913aef21e3ce23836e91b8cbb5f",
+    "zh:d4a56f8c48aa86fc8e0c233d56850f5783f322d6336f3bf1916e293246b6b5d4",
+    "zh:f2b394ebd4af33f343835517e80fc876f79361f4688220833bc3c77655dd2202",
+    "zh:f31982f29f12834e5d21e010856eddd19d59cd8f449adf470655bfd19354377e",
   ]
 }
 
@@ -72,6 +84,10 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:/GAVA/xheGQcbOZEq0qxANOg+KVLCA7Wv8qluxhTjhU=",
+    "h1:8oTPe2VUL6E2d3OcrvqyjI4Nn/Y/UEQN26WLk5O/B0g=",
+    "h1:Np4kERf9SMrqUi7DJ1rK3soMK14k49nfgE7l/ipQ5xw=",
+    "h1:fm2EuMlsdPTuv2tKwx3PMJzWJUh7aMtU9Eky7t4fMys=",
+    "h1:tjcGlQAFA0kmQ4vKkIPPUC4it1UYxLbg4YvHOWRAJHA=",
     "zh:0af29ce2b7b5712319bf6424cb58d13b852bf9a777011a545fac99c7fdcdf561",
     "zh:126063ea0d79dad1f68fa4e4d556793c0108ce278034f101d1dbbb2463924561",
     "zh:196bfb49086f22fd4db46033e01655b0e5e036a5582d250412cc690fa7995de5",
@@ -91,7 +107,11 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.2"
   constraints = ">= 2.0.0"
   hashes = [
+    "h1:Gef5VGfobY5uokA5nV/zFvWeMNR2Pmq79DH94QnNZPM=",
     "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+    "h1:m467k2tZ9cdFFgHW7LPBK2GLPH43LC6wc3ppxr8yvoE=",
+    "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
     "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
     "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 ## Provision the notifications  
 module "notifications" {
   source  = "appvia/notifications/aws"
-  version = "1.0.1"
+  version = "1.0.2"
 
   allowed_aws_services = ["cloudwatch.amazonaws.com"]
   create_sns_topic     = var.create_sns_topic


### PR DESCRIPTION
Bumping to notifications version 1.02 for:
*  trivy security issues fix
* cloudwatch logs retention days default (is now infinite).