### PR TITLE
feat/SA-251: passing cloudwatch retention down as a module variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ module "account_baseline_alarms" {
 | <a name="input_accounts_id_to_name"></a> [accounts\_id\_to\_name](#input\_accounts\_id\_to\_name) | A mapping of account id and account name - used by notification lamdba to map an account ID to a human readable name | `map(string)` | `{}` | no |
 | <a name="input_alarm_namespace"></a> [alarm\_namespace](#input\_alarm\_namespace) | The cloudwatch alarm namespace. | `string` | `"cis-benchmark"` | no |
 | <a name="input_cloudtrail_log_group_name"></a> [cloudtrail\_log\_group\_name](#input\_cloudtrail\_log\_group\_name) | The name of the CloudTrail log group to filter on. | `string` | `"aws-controltower/CloudTrailLogs"` | no |
+| <a name="input_cloudwatch_log_group_retention"></a> [cloudwatch\_log\_group\_retention](#input\_cloudwatch\_log\_group\_retention) | The retention period for the cloudwatch log group (for lambda function logs) in days | `string` | `"0"` | no |
 | <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | The boolean flag whether to create the SNS topic for alarms. | `bool` | `true` | no |
 | <a name="input_enable_administrator_sso_activity"></a> [enable\_administrator\_sso\_activity](#input\_enable\_administrator\_sso\_activity) | The boolean flag whether the administrator\_sso\_activity alarm is enabled or not. | `bool` | `true` | no |
 | <a name="input_enable_aws_config_changes"></a> [enable\_aws\_config\_changes](#input\_enable\_aws\_config\_changes) | The boolean flag whether the aws\_config\_changes alarm is enabled or not. | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -4,12 +4,13 @@ module "notifications" {
   source  = "appvia/notifications/aws"
   version = "1.0.3"
 
-  allowed_aws_services = ["cloudwatch.amazonaws.com"]
-  create_sns_topic     = var.create_sns_topic
-  email                = local.email_configuration
-  enable_slack         = local.enable_slack
-  slack                = local.slack_configuration
-  sns_topic_name       = var.sns_topic_name
-  tags                 = var.tags
-  accounts_id_to_name  = var.accounts_id_to_name
+  allowed_aws_services           = ["cloudwatch.amazonaws.com"]
+  create_sns_topic               = var.create_sns_topic
+  email                          = local.email_configuration
+  enable_slack                   = local.enable_slack
+  slack                          = local.slack_configuration
+  sns_topic_name                 = var.sns_topic_name
+  tags                           = var.tags
+  accounts_id_to_name            = var.accounts_id_to_name
+  cloudwatch_log_group_retention = var.cloudwatch_log_group_retention
 }

--- a/variables.tf
+++ b/variables.tf
@@ -156,3 +156,9 @@ variable "accounts_id_to_name" {
   type        = map(string)
   default     = {}
 }
+
+variable "cloudwatch_log_group_retention" {
+  description = "The retention period for the cloudwatch log group (for lambda function logs) in days"
+  type        = string
+  default     = "0"
+}


### PR DESCRIPTION
So it can be passed down from `terraform-aws-cloudaccess-lza`